### PR TITLE
Fix u128 hex string parsing

### DIFF
--- a/crates/common/serde_utils.rs
+++ b/crates/common/serde_utils.rs
@@ -192,7 +192,7 @@ pub mod u128 {
             D: Deserializer<'de>,
         {
             let value = String::deserialize(d)?;
-            let res = u128::from_str_radix(value.trim_start_matches("0x"), 32)
+            let res = u128::from_str_radix(value.trim_start_matches("0x"), 16)
                 .map_err(|_| D::Error::custom("Failed to deserialize u128 value"));
             res
         }

--- a/crates/common/types/requests.rs
+++ b/crates/common/types/requests.rs
@@ -193,24 +193,24 @@ impl Deposit {
         for (i, (expected_offset, expected_size)) in
             OFFSETS.into_iter().zip(SIZES.into_iter()).enumerate()
         {
-            let offset = fixed_bytes::<OFFSET_LEN>(data, i * OFFSET_LEN);
-            let size = fixed_bytes::<SIZE_LEN>(data, expected_offset);
+            let offset = fixed_bytes::<OFFSET_LEN>(data, i * OFFSET_LEN)?;
+            let size = fixed_bytes::<SIZE_LEN>(data, expected_offset)?;
             if !is_eq(offset, expected_offset) || !is_eq(size, expected_size) {
                 return None;
             }
         }
 
         // Extract Data
-        let pub_key: Bytes48 = fixed_bytes::<PUB_KEY_SIZE>(data, PUB_KEY_OFFSET + SIZE_LEN);
+        let pub_key: Bytes48 = fixed_bytes::<PUB_KEY_SIZE>(data, PUB_KEY_OFFSET + SIZE_LEN)?;
         let withdrawal_credentials: Bytes32 = fixed_bytes::<WITHDRAWAL_CREDENTIALS_SIZE>(
             data,
             WITHDRAWAL_CREDENTIALS_OFFSET + SIZE_LEN,
-        );
+        )?;
         let amount: u64 =
-            u64::from_le_bytes(fixed_bytes::<AMOUNT_SIZE>(data, AMOUNT_OFFSET + SIZE_LEN));
-        let signature: Bytes96 = fixed_bytes::<SIGNATURE_SIZE>(data, SIGNATURE_OFFSET + SIZE_LEN);
+            u64::from_le_bytes(fixed_bytes::<AMOUNT_SIZE>(data, AMOUNT_OFFSET + SIZE_LEN)?);
+        let signature: Bytes96 = fixed_bytes::<SIGNATURE_SIZE>(data, SIGNATURE_OFFSET + SIZE_LEN)?;
         let index: u64 =
-            u64::from_le_bytes(fixed_bytes::<INDEX_SIZE>(data, INDEX_OFFSET + SIZE_LEN));
+            u64::from_le_bytes(fixed_bytes::<INDEX_SIZE>(data, INDEX_OFFSET + SIZE_LEN)?);
 
         Some(Deposit {
             pub_key,
@@ -239,11 +239,8 @@ impl Deposit {
     }
 }
 
-fn fixed_bytes<const N: usize>(data: &[u8], offset: usize) -> [u8; N] {
-    data.get(offset..offset + N)
-        .expect("Couldn't convert to fixed bytes")
-        .try_into()
-        .expect("Couldn't convert to fixed bytes")
+fn fixed_bytes<const N: usize>(data: &[u8], offset: usize) -> Option<[u8; N]> {
+    data.get(offset..offset + N)?.try_into().ok()
 }
 
 // See https://github.com/ethereum/EIPs/blob/2a6b6965e64787815f7fffb9a4c27660d9683846/EIPS/eip-7685.md?plain=1#L62.


### PR DESCRIPTION
## Summary
- fix incorrect radix when parsing u128 hex strings in `serde_utils`
- avoid panics when parsing deposit logs by safely handling invalid byte slices

## Testing
- `cargo test -p ethrex-common --no-run`
- `cargo test -p ethrex-common`


------
https://chatgpt.com/codex/tasks/task_e_68403775a6608325a924ac220189d060