### PR TITLE
Fix hoodi bootnodes log typo

### DIFF
--- a/cmd/ethrex/initializers.rs
+++ b/cmd/ethrex/initializers.rs
@@ -253,7 +253,7 @@ pub fn get_bootnodes(opts: &Options, network: &Network, data_dir: &str) -> Vec<N
             bootnodes.extend(networks::HOLESKY_BOOTNODES.clone());
         }
         Network::PublicNetwork(PublicNetwork::Hoodi) => {
-            info!("Addig hoodi preset bootnodes");
+            info!("Adding hoodi preset bootnodes");
             bootnodes.extend(networks::HOODI_BOOTNODES.clone());
         }
         Network::PublicNetwork(PublicNetwork::Mainnet) => {


### PR DESCRIPTION
## Summary
- fix a typo in the Hoodi bootnodes log message

## Testing
- `cargo fmt -- cmd/ethrex/initializers.rs`

------
https://chatgpt.com/codex/tasks/task_e_6848226e656883258d4ec45e184cd9ac